### PR TITLE
Update default ringtone and notification tone

### DIFF
--- a/accountsservice/com.ubuntu.AccountsService.Sound.xml
+++ b/accountsservice/com.ubuntu.AccountsService.Sound.xml
@@ -19,7 +19,7 @@
         </property>
 
 	<property name="LastRunningPlayer" type="s" access="readwrite">
-             <annotation name="org.freedesktop.Accounts.DefaultValue.String" 
+             <annotation name="org.freedesktop.Accounts.DefaultValue.String"
                 value=""/>
         </property>
 

--- a/accountsservice/com.ubuntu.touch.AccountsService.Sound.xml
+++ b/accountsservice/com.ubuntu.touch.AccountsService.Sound.xml
@@ -9,12 +9,12 @@
         </property>
 
         <property name="IncomingCallSound" type="s" access="readwrite">
-            <annotation name="org.freedesktop.Accounts.DefaultValue.String" 
+            <annotation name="org.freedesktop.Accounts.DefaultValue.String"
                 value="/usr/share/sounds/ubuntu/ringtones/Ubuntu.ogg"/>
         </property>
 
         <property name="IncomingMessageSound" type="s" access="readwrite">
-            <annotation name="org.freedesktop.Accounts.DefaultValue.String" 
+            <annotation name="org.freedesktop.Accounts.DefaultValue.String"
                 value="/usr/share/sounds/ubuntu/notifications/Xylo.ogg"/>
         </property>
 

--- a/accountsservice/com.ubuntu.touch.AccountsService.Sound.xml
+++ b/accountsservice/com.ubuntu.touch.AccountsService.Sound.xml
@@ -10,12 +10,12 @@
 
         <property name="IncomingCallSound" type="s" access="readwrite">
             <annotation name="org.freedesktop.Accounts.DefaultValue.String"
-                value="/usr/share/sounds/ubuntu/ringtones/Ubuntu.ogg"/>
+                value="/usr/share/sounds/ubuntu/ringtones/UBports.ogg"/>
         </property>
 
         <property name="IncomingMessageSound" type="s" access="readwrite">
             <annotation name="org.freedesktop.Accounts.DefaultValue.String"
-                value="/usr/share/sounds/ubuntu/notifications/Xylo.ogg"/>
+                value="/usr/share/sounds/ubuntu/notifications/Sintesis.ogg"/>
         </property>
 
         <property name="IncomingCallVibrate" type="b" access="readwrite">

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+gsettings-ubuntu-touch-schemas (0.0.9+ubports0) xenial; urgency=medium
+
+  * Change default ringtones
+
+ -- Dalton Durst <dalton@ubports.com>  Fri, 5 Oct 2018 21:54:57 -0500
+
 gsettings-ubuntu-touch-schemas (0.0.8+ubports) xenial; urgency=medium
 
   * Imported to UBports

--- a/schemas/Makefile.am
+++ b/schemas/Makefile.am
@@ -1,4 +1,4 @@
-desktop_gschemas_in_in = \ 
+desktop_gschemas_in_in = \
 	com.ubuntu.notifications.hub.gschema.xml.in.in \
 	com.ubuntu.notifications.settings.gschema.xml.in.in \
 	com.ubuntu.phone.gschema.xml.in.in         \

--- a/schemas/com.ubuntu.touch.sound.gschema.xml.in.in
+++ b/schemas/com.ubuntu.touch.sound.gschema.xml.in.in
@@ -6,12 +6,12 @@
       <_description>Whether silent mode is active or not.</_description>
     </key>
     <key name="incoming-call-sound" type="s">
-      <default>"/usr/share/sounds/ubuntu/ringtones/Ubuntu.ogg"</default>
+      <default>"/usr/share/sounds/ubuntu/ringtones/UBports.ogg"</default>
       <_summary>Ringtone sound for the phone application.</_summary>
       <_description>This sound file is played, on incoming calls, by the phone application.</_description>
     </key>
     <key name="incoming-message-sound" type="s">
-      <default>"/usr/share/sounds/ubuntu/notifications/Xylo.ogg"</default>
+      <default>"/usr/share/sounds/ubuntu/notifications/Sintesis.ogg"</default>
       <_summary>Incoming message sound for the phone application.</_summary>
       <_description>This sound file is played, on incoming messages, by the phone application.</_description>
     </key>

--- a/schemas/com.ubuntu.user-interface.gschema.xml.in.in
+++ b/schemas/com.ubuntu.user-interface.gschema.xml.in.in
@@ -8,10 +8,10 @@
         The values are stored in a dictionary where the keys are IDs of monitors and the values are the scale factors.
         The scale factors are not the traditional float scale factors that one might expect. Instead they are integers
         that need to be divided by 8 before being used as regular scale factors.
-        That limits the number of possible scalings applied to the UI without jeopardizing flexibility (there is still 
+        That limits the number of possible scalings applied to the UI without jeopardizing flexibility (there is still
         enough possible scalings for all devices out there). This limiting allows for better testing since there is now
         only a finite number of possible scalings.
-        The scale factor also maps directly to the grid units used in the Ubuntu UI Toolkit where one grid unit is 
+        The scale factor also maps directly to the grid units used in the Ubuntu UI Toolkit where one grid unit is
         exactly equal to 'scale factor' number of pixels.
         </_description>
         </key>


### PR DESCRIPTION
This PR updates the default ringtone and notification tone for Ubuntu Touch.

The new default ringtone is Outer Passage's [Voyager I](https://soundcloud.com/outer-passage/voyager-i), which has been renamed to UBports for this release.

The new default notification tone is Outer Passage's [Sintesis](https://soundcloud.com/outer-passage/sintesis).

I've also removed trailing spaces from any lines in the package. What can I say, trailing whitespace bugs me...

This finishes and closes ubports/ubuntu-touch#895