### PR TITLE
add AccountsService "PinCodePromptManager" property

### DIFF
--- a/accountsservice/com.ubuntu.AccountsService.SecurityPrivacy.xml
+++ b/accountsservice/com.ubuntu.AccountsService.SecurityPrivacy.xml
@@ -12,6 +12,10 @@
       <annotation name="org.freedesktop.Accounts.DefaultValue" value="0"/>
     </property>
 
+    <property name="PinCodePromptManager" type="s" access="readwrite">
+      <annotation name="org.freedesktop.Accounts.DefaultValue.String" value="PinPrompt"/>
+    </property>
+
     <property name="EnableFingerprintIdentification" type="b" access="readwrite">
       <annotation name="org.freedesktop.Accounts.DefaultValue" value="false"/>
     </property>


### PR DESCRIPTION
This is part of the "PinCode prompt schema" work : refs https://github.com/ubports/ubuntu-touch/issues/1940
That allow us to define a prompt login manager in settings.

This PR is to merge first